### PR TITLE
fix: add missing click dependency for pipx installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ authors = [
 
 dependencies = [
     "typer>=0.12.0",
+    "click>=8.0.0",
     "rich>=13.0.0",
     "pyyaml>=6.0",
     "pydantic>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sklm"
-version = "0.1.4"
+version = "0.1.5"
 description = "Skills manager for AI agents"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sklm/cli/main.py
+++ b/sklm/cli/main.py
@@ -11,7 +11,6 @@ import traceback as tb_mod
 from pathlib import Path
 from typing import Optional
 
-import click
 import typer
 from rich.console import Console
 from rich.table import Table
@@ -115,13 +114,13 @@ def _prompt_cleanup(
 
 @app.callback()
 def main(
+    ctx: typer.Context,
     version: bool = typer.Option(
         False, "--version", "-V", help="Show version", callback=version_callback
     ),
 ):
     global _tracker_start, _tracker_command
     _tracker_start = time.monotonic()
-    ctx = click.get_current_context()
     _tracker_command = ctx.invoked_subcommand or ""
 
 


### PR DESCRIPTION
Typer no longer transitively installs `click`, but `sklm/cli/main.py` imports it directly at module load. This caused `ModuleNotFoundError: No module named 'click'` when running the `sklm` entry point installed via pipx.

Add `click>=8.0.0` to `pyproject.toml` dependencies.