### PR TITLE
feat: interactive TUI for managing project skills

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,6 @@ sklm = "sklm.cli.main:run"
 
 [tool.setuptools.packages.find]
 include = ["sklm*"]
+
+[tool.setuptools.package-data]
+sklm = ["agents/agents.yaml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ authors = [
 dependencies = [
     "typer>=0.12.0",
     "rich>=13.0.0",
+    "textual>=0.50.0",
     "pyyaml>=6.0",
     "pydantic>=2.0.0",
     "umami-analytics>=0.2.0",

--- a/sklm/api.py
+++ b/sklm/api.py
@@ -229,6 +229,73 @@ class Sklm:
     def info(self, kind: ResourceKind, name: str) -> Optional[ResourceRef]:
         return get_resource_info(self.workspace, self.global_store, kind, name)
 
+    # ── TUI helpers ───────────────────────────────────────────────────────
+
+    def list_available_skills(self) -> list[ResourceRef]:
+        """Skills that can be added: global store + registries, deduped."""
+        seen: set[str] = set()
+        refs: list[ResourceRef] = []
+        for r in self.global_store.list_resources(ResourceKind.skill):
+            if r.name not in seen:
+                refs.append(ResourceRef(name=r.name, kind=r.kind, origin="global", path=r.path))
+                seen.add(r.name)
+        for reg_name, resource in self.registry_manager.search("", type_filter=ResourceKind.skill):
+            if resource.name not in seen:
+                refs.append(ResourceRef(
+                    name=resource.name,
+                    kind=resource.kind,
+                    origin=f"registry:{reg_name}",
+                    path=resource.path,
+                ))
+                seen.add(resource.name)
+        return sorted(refs, key=lambda r: r.name)
+
+    def list_workspace_skills(self) -> list[ResourceRef]:
+        """Skills currently linked in the workspace."""
+        return sorted(
+            (r for r in self.workspace.list_resources(ResourceKind.skill) if r.linked),
+            key=lambda r: r.name,
+        )
+
+    def add_skills(self, names: list[str]) -> list[ResourceRef]:
+        """Add and link multiple skills, then sync agents."""
+        refs: list[ResourceRef] = []
+        for name in names:
+            refs.append(self.add(ResourceKind.skill, name))
+        return refs
+
+    def remove_skills(self, names: list[str]) -> list[ResourceRef]:
+        """Unlink and remove multiple skills, then sync agents."""
+        refs: list[ResourceRef] = []
+        for name in names:
+            refs.append(self.remove(ResourceKind.skill, name))
+        return refs
+
+    def import_agent_project_skills(self, agent_id: str) -> list[ResourceRef]:
+        """Import skills found in the agent's project dir into the workspace."""
+        adapter = self._find_adapter_by_name(agent_id)
+        if not adapter:
+            return []
+        skills_path = adapter.get_skills_path(self.project_root)
+        if not skills_path.exists():
+            return []
+        imported: list[ResourceRef] = []
+        for skill_dir in sorted(skills_path.iterdir()):
+            if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").exists():
+                continue
+            if self.workspace.get_link(ResourceKind.skill, skill_dir.name):
+                continue
+            if not self.global_store.get_resource(ResourceKind.skill, skill_dir.name):
+                self.global_store.add_resource(ResourceKind.skill, skill_dir)
+            ref = add_resource_to_workspace(
+                self.workspace, self.global_store, self.registry_manager, skill_dir.name
+            )
+            _link_resource(self.workspace, self.global_store, ResourceKind.skill, skill_dir.name)
+            imported.append(ref)
+        if imported:
+            self.agent_sync()
+        return imported
+
     # ── Linking (internal) ───────────────────────────────────────────────
 
     def link(self, kind: ResourceKind, name: str) -> Link:

--- a/sklm/api.py
+++ b/sklm/api.py
@@ -185,6 +185,7 @@ class Sklm:
         name: str,
         from_url: Optional[str] = None,
         subdir: Optional[str] = None,
+        _sync: bool = True,
     ) -> ResourceRef:
         if from_url:
             ref = self.install(kind, name, from_url=from_url, subdir=subdir)
@@ -197,30 +198,32 @@ class Sklm:
             if not existing and ref.path:
                 self.global_store.add_resource(kind, ref.path, ref.name)
         _link_resource(self.workspace, self.global_store, kind, ref.name)
-        try:
-            self.agent_sync()
-        except RuntimeError:
-            console.print(
-                "[yellow]⚠[/] Skill installed but no agent configured — "
-                "not synced to any agent directory."
-            )
-            console.print(
-                "   Run [bold]sklm init --agent <name>[/] to configure an agent."
-            )
+        if _sync:
+            try:
+                self.agent_sync()
+            except RuntimeError:
+                console.print(
+                    "[yellow]⚠[/] Skill installed but no agent configured — "
+                    "not synced to any agent directory."
+                )
+                console.print(
+                    "   Run [bold]sklm init --agent <name>[/] to configure an agent."
+                )
         return ref
 
-    def remove(self, kind: ResourceKind, name: str) -> ResourceRef:
+    def remove(self, kind: ResourceKind, name: str, _sync: bool = True) -> ResourceRef:
         ref = remove_resource_from_workspace(self.workspace, kind, name)
-        try:
-            self.agent_sync()
-        except RuntimeError:
-            console.print(
-                "[yellow]⚠[/] Skill removed but no agent configured — "
-                "agent directory not cleaned."
-            )
-            console.print(
-                "   Run [bold]sklm init --agent <name>[/] to configure an agent."
-            )
+        if _sync:
+            try:
+                self.agent_sync()
+            except RuntimeError:
+                console.print(
+                    "[yellow]⚠[/] Skill removed but no agent configured — "
+                    "agent directory not cleaned."
+                )
+                console.print(
+                    "   Run [bold]sklm init --agent <name>[/] to configure an agent."
+                )
         return ref
 
     def list(self, kind: Optional[ResourceKind] = None) -> list[ResourceRef]:
@@ -258,17 +261,37 @@ class Sklm:
         )
 
     def add_skills(self, names: list[str]) -> list[ResourceRef]:
-        """Add and link multiple skills, then sync agents."""
+        """Add and link multiple skills, then sync agents once."""
         refs: list[ResourceRef] = []
         for name in names:
-            refs.append(self.add(ResourceKind.skill, name))
+            refs.append(self.add(ResourceKind.skill, name, _sync=False))
+        try:
+            self.agent_sync()
+        except RuntimeError:
+            console.print(
+                "[yellow]⚠[/] Skills added but no agent configured — "
+                "not synced to any agent directory."
+            )
+            console.print(
+                "   Run [bold]sklm init --agent <name>[/] to configure an agent."
+            )
         return refs
 
     def remove_skills(self, names: list[str]) -> list[ResourceRef]:
-        """Unlink and remove multiple skills, then sync agents."""
+        """Unlink and remove multiple skills, then sync agents once."""
         refs: list[ResourceRef] = []
         for name in names:
-            refs.append(self.remove(ResourceKind.skill, name))
+            refs.append(self.remove(ResourceKind.skill, name, _sync=False))
+        try:
+            self.agent_sync()
+        except RuntimeError:
+            console.print(
+                "[yellow]⚠[/] Skills removed but no agent configured — "
+                "agent directory not cleaned."
+            )
+            console.print(
+                "   Run [bold]sklm init --agent <name>[/] to configure an agent."
+            )
         return refs
 
     def import_agent_project_skills(self, agent_id: str) -> list[ResourceRef]:
@@ -280,18 +303,32 @@ class Sklm:
         if not skills_path.exists():
             return []
         imported: list[ResourceRef] = []
-        for skill_dir in sorted(skills_path.iterdir()):
-            if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").exists():
+        try:
+            entries = sorted(skills_path.iterdir())
+        except (PermissionError, OSError) as e:
+            import sys
+            print(f"[warning] Could not read skills directory {skills_path}: {e}", file=sys.stderr)
+            return []
+        for skill_dir in entries:
+            try:
+                if not skill_dir.is_dir() or not (skill_dir / "SKILL.md").exists():
+                    continue
+                if self.workspace.get_link(ResourceKind.skill, skill_dir.name):
+                    continue
+                if not self.global_store.get_resource(ResourceKind.skill, skill_dir.name):
+                    self.global_store.add_resource(ResourceKind.skill, skill_dir)
+                ref = add_resource_to_workspace(
+                    self.workspace, self.global_store, self.registry_manager, skill_dir.name
+                )
+                _link_resource(self.workspace, self.global_store, ResourceKind.skill, skill_dir.name)
+                imported.append(ref)
+            except Exception as e:
+                import sys
+                print(
+                    f"[warning] Failed to import skill '{skill_dir.name}': {e}",
+                    file=sys.stderr,
+                )
                 continue
-            if self.workspace.get_link(ResourceKind.skill, skill_dir.name):
-                continue
-            if not self.global_store.get_resource(ResourceKind.skill, skill_dir.name):
-                self.global_store.add_resource(ResourceKind.skill, skill_dir)
-            ref = add_resource_to_workspace(
-                self.workspace, self.global_store, self.registry_manager, skill_dir.name
-            )
-            _link_resource(self.workspace, self.global_store, ResourceKind.skill, skill_dir.name)
-            imported.append(ref)
         if imported:
             self.agent_sync()
         return imported

--- a/sklm/cli/main.py
+++ b/sklm/cli/main.py
@@ -388,10 +388,15 @@ def add(
             raise typer.Exit(0)
         console.print(f"[green]✓[/] Added {len(result)} skill(s)")
         return
+    if name is None:
+        console.print(
+            "[red]✗[/] Resource name is required. Usage: [bold]sklm add <type> <name>[/]"
+        )
+        raise typer.Exit(1)
     f = get_sklm()
     kind = parse_resource_type(resource_type)
     try:
-        ref = f.add(kind, name or "", from_url=from_url, subdir=subdir)
+        ref = f.add(kind, name, from_url=from_url, subdir=subdir)
     except (FileNotFoundError, FileExistsError, ValueError) as e:
         console.print(f"[red]✗[/] {e}")
         raise typer.Exit(1) from e
@@ -416,10 +421,15 @@ def rm(
             raise typer.Exit(0)
         console.print(f"[green]✓[/] Removed {len(result)} skill(s)")
         return
+    if name is None:
+        console.print(
+            "[red]✗[/] Resource name is required. Usage: [bold]sklm rm <type> <name>[/]"
+        )
+        raise typer.Exit(1)
     f = get_sklm()
     kind = parse_resource_type(resource_type)
     try:
-        ref = f.remove(kind, name or "")
+        ref = f.remove(kind, name)
     except (KeyError, RuntimeError) as e:
         console.print(f"[red]✗[/] {e}")
         raise typer.Exit(1) from e

--- a/sklm/cli/main.py
+++ b/sklm/cli/main.py
@@ -11,7 +11,6 @@ import traceback as tb_mod
 from pathlib import Path
 from typing import Optional
 
-import click
 import typer
 from rich.console import Console
 from rich.table import Table
@@ -115,13 +114,13 @@ def _prompt_cleanup(
 
 @app.callback()
 def main(
+    ctx: typer.Context,
     version: bool = typer.Option(
         False, "--version", "-V", help="Show version", callback=version_callback
     ),
 ):
     global _tracker_start, _tracker_command
     _tracker_start = time.monotonic()
-    ctx = click.get_current_context()
     _tracker_command = ctx.invoked_subcommand or ""
 
 
@@ -234,6 +233,9 @@ def status(
     table.add_row("Skills", str(state["skills"]))
     table.add_row("Total links", str(state["total_links"]))
     table.add_row("Broken links", str(state["broken_links"]))
+    linked = f.list_workspace_skills()
+    if linked:
+        table.add_row("Active project skills", ", ".join(r.name for r in linked))
     console.print(table)
     if state["broken_links"] > 0:
         console.print("\n[yellow]💡 Tip:[/] Run [bold]sklm status --repair[/] to fix broken links")
@@ -364,8 +366,12 @@ def migrate(
 
 @app.command()
 def add(
-    resource_type: str = typer.Argument(..., help="Resource type: skill"),
-    name: str = typer.Argument(..., help="Resource name (optionally prefixed: registry:name)"),
+    resource_type: Optional[str] = typer.Argument(
+        None, help="Resource type: skill (omit to use interactive picker)"
+    ),
+    name: Optional[str] = typer.Argument(
+        None, help="Resource name (optionally prefixed: registry:name)"
+    ),
     from_url: Optional[str] = typer.Option(
         None, "--from", help="Git repository URL to install from"
     ),
@@ -373,11 +379,19 @@ def add(
         None, "--subdir", help="Subdirectory within the repo (default: skills/<name>)"
     ),
 ):
-    """Add and activate a resource in the project (resolves, stores, links, syncs agent)."""
+    """Add and activate a resource in the project. Launch interactive picker when no args given."""
+    if resource_type is None:
+        from sklm.tui import run_tui
+
+        result = run_tui("add")
+        if result is None:
+            raise typer.Exit(0)
+        console.print(f"[green]✓[/] Added {len(result)} skill(s)")
+        return
     f = get_sklm()
     kind = parse_resource_type(resource_type)
     try:
-        ref = f.add(kind, name, from_url=from_url, subdir=subdir)
+        ref = f.add(kind, name or "", from_url=from_url, subdir=subdir)
     except (FileNotFoundError, FileExistsError, ValueError) as e:
         console.print(f"[red]✗[/] {e}")
         raise typer.Exit(1) from e
@@ -386,18 +400,41 @@ def add(
 
 @app.command()
 def rm(
-    resource_type: str = typer.Argument(..., help="Resource type: skill"),
-    name: str = typer.Argument(..., help="Resource name to remove"),
+    resource_type: Optional[str] = typer.Argument(
+        None, help="Resource type: skill (omit to use interactive picker)"
+    ),
+    name: Optional[str] = typer.Argument(
+        None, help="Resource name to remove"
+    ),
 ):
-    """Remove a resource from the workspace (unlinks and syncs agent)."""
+    """Remove a resource from the workspace. Launch interactive picker when no args given."""
+    if resource_type is None:
+        from sklm.tui import run_tui
+
+        result = run_tui("remove")
+        if result is None:
+            raise typer.Exit(0)
+        console.print(f"[green]✓[/] Removed {len(result)} skill(s)")
+        return
     f = get_sklm()
     kind = parse_resource_type(resource_type)
     try:
-        ref = f.remove(kind, name)
+        ref = f.remove(kind, name or "")
     except (KeyError, RuntimeError) as e:
         console.print(f"[red]✗[/] {e}")
         raise typer.Exit(1) from e
     console.print(f"[green]✓[/] Removed {kind.value} [bold]{ref.name}[/]")
+
+
+@app.command()
+def skills():
+    """Open interactive skill manager."""
+    from sklm.tui import run_tui
+
+    result = run_tui("manage")
+    if result is None:
+        return
+    console.print(f"[green]✓[/] Updated {len(result)} skill(s)")
 
 
 @app.command()

--- a/sklm/tui.py
+++ b/sklm/tui.py
@@ -70,11 +70,10 @@ class SkillTui(App):
         return "[blue]Manage Project Skills[/]"
 
     def on_mount(self) -> None:
-        self.run_worker(self._load_skills(), exclusive=True)
+        self.run_worker(self._load_skills, exclusive=True, thread=True)
 
-    async def _load_skills(self) -> None:
+    def _load_skills(self) -> None:
         """Load skills from Sklm API in a background thread."""
-        loading = self.query_one("#loading", Label)
         try:
             if self.mode in ("add", "manage"):
                 for ref in self.sklm.list_available_skills():
@@ -83,9 +82,14 @@ class SkillTui(App):
                 for ref in self.sklm.list_workspace_skills():
                     self._all_rows.append((ref, True))
         except Exception as e:
-            loading.update(f"[red]Error loading skills:[/] {e}")
+            self.call_from_thread(self._render_error, str(e))
             return
         self.call_from_thread(self._render_rows)
+
+    def _render_error(self, error_msg: str) -> None:
+        """Display a loading error on the UI thread."""
+        loading = self.query_one("#loading", Label)
+        loading.update(f"[red]Error loading skills:[/] {error_msg}")
 
     def _render_rows(self, filter_text: str = "") -> None:
         """Render skill rows, filtering by filter_text."""

--- a/sklm/tui.py
+++ b/sklm/tui.py
@@ -1,0 +1,125 @@
+"""Interactive TUI for managing project skills.
+
+ponytail: one-screen app, no router; add/remove modes swap the action button.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, Checkbox, Header, Label
+
+from sklm.api import Sklm
+from sklm.models import ResourceKind, ResourceRef
+
+
+class SkillTui(App):
+    """Multi-select skill manager."""
+
+    CSS = """
+    Screen { align: center middle; }
+    #container { width: 80; height: auto; border: solid green; padding: 1 2; }
+    #title { text-align: center; }
+    #list { height: auto; max-height: 20; overflow-y: scroll; }
+    .row { height: auto; padding: 0 1; }
+    #footer { margin-top: 1; }
+    """
+
+    BINDINGS = [("q", "quit", "Quit")]
+
+    def __init__(self, mode: str = "manage") -> None:
+        super().__init__()
+        self.mode = mode  # "add" | "remove" | "manage"
+        self.sklm = Sklm()
+        self.result: list[ResourceRef] = []
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with Vertical(id="container"):
+            yield Label(self._title(), id="title")
+            with Vertical(id="list"):
+                yield Label("Loading skills...", id="loading")
+            with Horizontal(id="footer"):
+                if self.mode in ("add", "manage"):
+                    yield Button("Add selected", id="add", variant="success")
+                if self.mode in ("remove", "manage"):
+                    yield Button("Remove selected", id="remove", variant="error")
+                yield Button("Cancel", id="cancel")
+
+    def _title(self) -> str:
+        if self.mode == "add":
+            return "Add skills to project"
+        if self.mode == "remove":
+            return "Remove skills from project"
+        return "Manage project skills"
+
+    def on_mount(self) -> None:
+        list_box = self.query_one("#list", Vertical)
+        loading = self.query_one("#loading", Label)
+        rows: list[Vertical] = []
+        try:
+            if self.mode in ("add", "manage"):
+                for ref in self.sklm.list_available_skills():
+                    rows.append(self._row(ref, False))
+            if self.mode in ("remove", "manage"):
+                for ref in self.sklm.list_workspace_skills():
+                    rows.append(self._row(ref, True))
+        except Exception as e:
+            loading.update(f"[red]Error loading skills:[/] {e}")
+            return
+        loading.remove()
+        if not rows:
+            list_box.mount(Label("[dim]No skills available.[/]"))
+            return
+        for row in rows:
+            list_box.mount(row)
+
+    def _row(self, ref: ResourceRef, checked: bool) -> Vertical:
+        cb = Checkbox(f"{ref.name}  [dim]({ref.origin})[/]", value=checked)
+        cb.data = ref  # ponytail: stash ref on widget for action handler
+        return Vertical(cb, classes="row")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        button_id = event.button.id
+        if button_id == "cancel":
+            self.exit(None)
+            return
+
+        refs = [
+            cb.data
+            for row in self.query(".row")
+            for cb in row.query(Checkbox)
+            if cb.value
+        ]
+        if not refs:
+            self.notify("No skills selected", severity="warning")
+            return
+
+        try:
+            if button_id == "add":
+                self.result = self.sklm.add_skills([r.name for r in refs])
+            else:
+                self.result = self.sklm.remove_skills([r.name for r in refs])
+        except Exception as e:
+            self.notify(f"Failed: {e}", severity="error")
+            return
+        self.exit(self.result)
+
+
+def run_tui(mode: str = "manage") -> Optional[list[ResourceRef]]:
+    if not sys.stdout.isatty():
+        print("Interactive mode requires a TTY. Use sklm add/rm with arguments instead.", file=sys.stderr)
+        return None
+    sklm = Sklm()
+    if not sklm.workspace.exists():
+        print("No Sklm workspace found. Run 'sklm init' first.", file=sys.stderr)
+        return None
+    # ponytail: auto-import existing skills from all configured agents
+    for agent in sklm.workspace.load_config().agents:
+        if agent != "none":
+            sklm.import_agent_project_skills(agent)
+    app = SkillTui(mode=mode)
+    return app.run()

--- a/sklm/tui.py
+++ b/sklm/tui.py
@@ -45,6 +45,7 @@ class SkillTui(App):
         self.sklm = sklm or Sklm()
         self.result: list[ResourceRef] = []
         self._all_rows: list[tuple[ResourceRef, bool]] = []
+        self._rendered = False
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -88,14 +89,18 @@ class SkillTui(App):
 
     def _render_error(self, error_msg: str) -> None:
         """Display a loading error on the UI thread."""
-        loading = self.query_one("#loading", Label)
-        loading.update(f"[red]Error loading skills:[/] {error_msg}")
+        if not self._rendered:
+            self.query_one("#loading", Label).update(
+                f"[red]Error loading skills:[/] {error_msg}"
+            )
+            self._rendered = True
 
     def _render_rows(self, filter_text: str = "") -> None:
         """Render skill rows, filtering by filter_text."""
         list_box = self.query_one("#list", Vertical)
-        loading = self.query_one("#loading", Label)
-        loading.remove()
+        if not self._rendered:
+            self.query_one("#loading", Label).remove()
+            self._rendered = True
 
         # Remove existing skill rows
         for row in list_box.query(".skill-row"):

--- a/sklm/tui.py
+++ b/sklm/tui.py
@@ -30,10 +30,10 @@ class SkillTui(App):
 
     BINDINGS = [("q", "quit", "Quit")]
 
-    def __init__(self, mode: str = "manage") -> None:
+    def __init__(self, mode: str = "manage", sklm: Optional[Sklm] = None) -> None:
         super().__init__()
         self.mode = mode  # "add" | "remove" | "manage"
-        self.sklm = Sklm()
+        self.sklm = sklm or Sklm()
         self.result: list[ResourceRef] = []
 
     def compose(self) -> ComposeResult:
@@ -121,5 +121,5 @@ def run_tui(mode: str = "manage") -> Optional[list[ResourceRef]]:
     for agent in sklm.workspace.load_config().agents:
         if agent != "none":
             sklm.import_agent_project_skills(agent)
-    app = SkillTui(mode=mode)
+    app = SkillTui(mode=mode, sklm=sklm)
     return app.run()

--- a/sklm/tui.py
+++ b/sklm/tui.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical
-from textual.widgets import Button, Checkbox, Footer, Header, Input, Label
+from textual.widgets import Button, Checkbox, Footer, Header, Input, Label, Markdown
 
 from sklm.api import Sklm
 from sklm.models import ResourceRef
@@ -25,10 +25,15 @@ class SkillTui(App):
     #title { text-align: center; }
     .skill-row { height: auto; padding: 0 1; }
     .skill-row:hover { background: $surface; }
-    #list { height: 1fr; overflow-y: scroll; }
+    #body { height: 1fr; }
+    #list-panel { width: 40%; overflow-y: auto; border-right: solid $primary; }
+    #preview-panel { width: 60%; padding: 0 1; overflow-y: auto; }
+    #preview-placeholder { color: $text-muted; text-align: center; margin-top: 2; }
+    .-hidden { display: none; }
     #filter { margin-bottom: 1; }
     #loading { color: $text-muted; text-align: center; }
     #stats { color: $text-muted; }
+    .section-header { color: $text-muted; text-style: bold; padding: 0 1; }
     #footer { margin-top: 1; }
     """
 
@@ -46,14 +51,19 @@ class SkillTui(App):
         self.result: list[ResourceRef] = []
         self._all_rows: list[tuple[ResourceRef, bool]] = []
         self._rendered = False
+        self._visible_count = 0
 
     def compose(self) -> ComposeResult:
         yield Header()
         with Vertical(id="container"):
             yield Label(self._title(), id="title")
             yield Input(placeholder="Type to filter skills...", id="filter")
-            with Vertical(id="list"):
-                yield Label("Loading skills...", id="loading")
+            with Horizontal(id="body"):
+                with Vertical(id="list-panel"):
+                    yield Label("Loading skills...", id="loading")
+                with Vertical(id="preview-panel"):
+                    yield Label("Select a skill to preview", id="preview-placeholder")
+                    yield Markdown(id="preview")
             with Horizontal(id="footer"):
                 yield Label("0 selected", id="stats")
                 if self.mode in ("add", "manage"):
@@ -97,12 +107,15 @@ class SkillTui(App):
 
     def _render_rows(self, filter_text: str = "") -> None:
         """Render skill rows, filtering by filter_text."""
-        list_box = self.query_one("#list", Vertical)
+        list_box = self.query_one("#list-panel", Vertical)
         if not self._rendered:
             self.query_one("#loading", Label).remove()
             self._rendered = True
 
-        # Remove existing skill rows
+        # Remove empty label, section headers, and existing skill rows
+        list_box.query("#empty").remove()
+        for row in list_box.query(".section-header"):
+            row.remove()
         for row in list_box.query(".skill-row"):
             row.remove()
 
@@ -112,17 +125,40 @@ class SkillTui(App):
             if not filter_text or filter_text.lower() in ref.name.lower()
         ]
 
+        # Sort by origin, then by name within each origin
+        rows_to_show.sort(key=lambda x: (x[0].origin, x[0].name))
+
+        self._visible_count = len(rows_to_show)
+
         if not rows_to_show:
-            list_box.mount(Label("[dim]No skills available.[/]"))
+            list_box.mount(Label("[dim]No skills available.[/]", id="empty"))
             return
 
+        # Group by origin with section headers
+        current_origin = None
         for ref, checked in rows_to_show:
+            if ref.origin != current_origin:
+                current_origin = ref.origin
+                list_box.mount(
+                    Label(f"── {current_origin} ──", classes="section-header")
+                )
             list_box.mount(self._row(ref, checked))
 
         self._update_stats()
 
+    @staticmethod
+    def _origin_badge(origin: str) -> str:
+        """Return a Rich-markup badge for the given origin."""
+        if origin == "global":
+            return f"[green]{origin}[/]"
+        if origin == "local":
+            return f"[yellow]{origin}[/]"
+        if origin.startswith("registry:"):
+            return f"[cyan]{origin}[/]"
+        return f"[dim]{origin}[/]"
+
     def _row(self, ref: ResourceRef, checked: bool) -> Vertical:
-        cb = Checkbox(f"{ref.name}  [dim]({ref.origin})[/]", value=checked)
+        cb = Checkbox(f"{ref.name}  {self._origin_badge(ref.origin)}", value=checked)
         cb.data = ref  # ponytail: stash ref on widget for action handler
         return Vertical(cb, classes="skill-row")
 
@@ -134,11 +170,39 @@ class SkillTui(App):
             for cb in row.query(Checkbox)
             if cb.value
         )
-        self.query_one("#stats", Label).update(f"{count} selected")
+        self.query_one("#stats", Label).update(
+            f"{count} / {self._visible_count} selected"
+        )
+
+    def _update_preview(self, ref: ResourceRef | None) -> None:
+        """Update the preview panel with the given skill's SKILL.md content."""
+        placeholder = self.query_one("#preview-placeholder", Label)
+        preview = self.query_one("#preview", Markdown)
+        if ref is None or ref.path is None:
+            placeholder.remove_class("-hidden")
+            preview.update("")
+            return
+
+        skill_md = ref.path / "SKILL.md"
+        if not skill_md.exists():
+            placeholder.remove_class("-hidden")
+            preview.update("")
+            return
+
+        try:
+            content = skill_md.read_text(encoding="utf-8")
+            placeholder.add_class("-hidden")
+            preview.update(content)
+        except Exception:
+            placeholder.remove_class("-hidden")
+            preview.update("")
+            self.notify("Failed to read SKILL.md", severity="error")
 
     def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
-        """Handle checkbox toggle to update stats."""
+        """Handle checkbox toggle to update stats and preview."""
         self._update_stats()
+        ref: ResourceRef | None = event.checkbox.data
+        self._update_preview(ref)
 
     def on_input_changed(self, event: Input.Changed) -> None:
         """Filter skill list as user types."""

--- a/sklm/tui.py
+++ b/sklm/tui.py
@@ -10,10 +10,10 @@ from typing import Optional
 
 from textual.app import App, ComposeResult
 from textual.containers import Horizontal, Vertical
-from textual.widgets import Button, Checkbox, Header, Label
+from textual.widgets import Button, Checkbox, Footer, Header, Input, Label
 
 from sklm.api import Sklm
-from sklm.models import ResourceKind, ResourceRef
+from sklm.models import ResourceRef
 
 
 class SkillTui(App):
@@ -21,66 +21,140 @@ class SkillTui(App):
 
     CSS = """
     Screen { align: center middle; }
-    #container { width: 80; height: auto; border: solid green; padding: 1 2; }
+    #container { width: 90%; height: 90%; border: solid $primary; padding: 1 2; }
     #title { text-align: center; }
-    #list { height: auto; max-height: 20; overflow-y: scroll; }
-    .row { height: auto; padding: 0 1; }
+    .skill-row { height: auto; padding: 0 1; }
+    .skill-row:hover { background: $surface; }
+    #list { height: 1fr; overflow-y: scroll; }
+    #filter { margin-bottom: 1; }
+    #loading { color: $text-muted; text-align: center; }
+    #stats { color: $text-muted; }
     #footer { margin-top: 1; }
     """
 
-    BINDINGS = [("q", "quit", "Quit")]
+    BINDINGS = [
+        ("ctrl+a", "select_all", "Select All"),
+        ("ctrl+d", "deselect_all", "Deselect All"),
+        ("enter", "confirm", "Confirm"),
+        ("q", "quit", "Quit"),
+    ]
 
     def __init__(self, mode: str = "manage", sklm: Optional[Sklm] = None) -> None:
         super().__init__()
         self.mode = mode  # "add" | "remove" | "manage"
         self.sklm = sklm or Sklm()
         self.result: list[ResourceRef] = []
+        self._all_rows: list[tuple[ResourceRef, bool]] = []
 
     def compose(self) -> ComposeResult:
         yield Header()
         with Vertical(id="container"):
             yield Label(self._title(), id="title")
+            yield Input(placeholder="Type to filter skills...", id="filter")
             with Vertical(id="list"):
                 yield Label("Loading skills...", id="loading")
             with Horizontal(id="footer"):
+                yield Label("0 selected", id="stats")
                 if self.mode in ("add", "manage"):
                     yield Button("Add selected", id="add", variant="success")
                 if self.mode in ("remove", "manage"):
                     yield Button("Remove selected", id="remove", variant="error")
                 yield Button("Cancel", id="cancel")
+        yield Footer()
 
     def _title(self) -> str:
         if self.mode == "add":
-            return "Add skills to project"
+            return "[green]Add Skills to Project[/]"
         if self.mode == "remove":
-            return "Remove skills from project"
-        return "Manage project skills"
+            return "[red]Remove Skills from Project[/]"
+        return "[blue]Manage Project Skills[/]"
 
     def on_mount(self) -> None:
-        list_box = self.query_one("#list", Vertical)
+        self.run_worker(self._load_skills(), exclusive=True)
+
+    async def _load_skills(self) -> None:
+        """Load skills from Sklm API in a background thread."""
         loading = self.query_one("#loading", Label)
-        rows: list[Vertical] = []
         try:
             if self.mode in ("add", "manage"):
                 for ref in self.sklm.list_available_skills():
-                    rows.append(self._row(ref, False))
+                    self._all_rows.append((ref, False))
             if self.mode in ("remove", "manage"):
                 for ref in self.sklm.list_workspace_skills():
-                    rows.append(self._row(ref, True))
+                    self._all_rows.append((ref, True))
         except Exception as e:
             loading.update(f"[red]Error loading skills:[/] {e}")
             return
+        self.call_from_thread(self._render_rows)
+
+    def _render_rows(self, filter_text: str = "") -> None:
+        """Render skill rows, filtering by filter_text."""
+        list_box = self.query_one("#list", Vertical)
+        loading = self.query_one("#loading", Label)
         loading.remove()
-        if not rows:
+
+        # Remove existing skill rows
+        for row in list_box.query(".skill-row"):
+            row.remove()
+
+        rows_to_show = [
+            (ref, checked)
+            for ref, checked in self._all_rows
+            if not filter_text or filter_text.lower() in ref.name.lower()
+        ]
+
+        if not rows_to_show:
             list_box.mount(Label("[dim]No skills available.[/]"))
             return
-        for row in rows:
-            list_box.mount(row)
+
+        for ref, checked in rows_to_show:
+            list_box.mount(self._row(ref, checked))
+
+        self._update_stats()
 
     def _row(self, ref: ResourceRef, checked: bool) -> Vertical:
         cb = Checkbox(f"{ref.name}  [dim]({ref.origin})[/]", value=checked)
         cb.data = ref  # ponytail: stash ref on widget for action handler
-        return Vertical(cb, classes="row")
+        return Vertical(cb, classes="skill-row")
+
+    def _update_stats(self) -> None:
+        """Update the selected count label."""
+        count = sum(
+            1
+            for row in self.query(".skill-row")
+            for cb in row.query(Checkbox)
+            if cb.value
+        )
+        self.query_one("#stats", Label).update(f"{count} selected")
+
+    def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
+        """Handle checkbox toggle to update stats."""
+        self._update_stats()
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        """Filter skill list as user types."""
+        self._render_rows(event.value)
+
+    def action_select_all(self) -> None:
+        """Select all visible skills."""
+        for row in self.query(".skill-row"):
+            for cb in row.query(Checkbox):
+                cb.value = True
+        self._update_stats()
+
+    def action_deselect_all(self) -> None:
+        """Deselect all visible skills."""
+        for row in self.query(".skill-row"):
+            for cb in row.query(Checkbox):
+                cb.value = False
+        self._update_stats()
+
+    def action_confirm(self) -> None:
+        """Press the primary action button."""
+        if self.mode in ("add", "manage"):
+            self.query_one("#add", Button).press()
+        elif self.mode == "remove":
+            self.query_one("#remove", Button).press()
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         button_id = event.button.id
@@ -90,7 +164,7 @@ class SkillTui(App):
 
         refs = [
             cb.data
-            for row in self.query(".row")
+            for row in self.query(".skill-row")
             for cb in row.query(Checkbox)
             if cb.value
         ]

--- a/tests/test_tui_api.py
+++ b/tests/test_tui_api.py
@@ -1,5 +1,7 @@
 """Self-check for TUI API helpers."""
 
+from __future__ import annotations
+
 from sklm.api import Sklm
 
 

--- a/tests/test_tui_api.py
+++ b/tests/test_tui_api.py
@@ -1,0 +1,27 @@
+"""Self-check for TUI API helpers."""
+
+from sklm.api import Sklm
+
+
+def test_tui_helpers():
+    s = Sklm()
+    available = s.list_available_skills()
+    assert isinstance(available, list)
+    # global store skills are offered
+    assert all(r.kind.value == "skill" for r in available)
+
+    workspace = s.list_workspace_skills()
+    assert isinstance(workspace, list)
+    # no duplicates between available list
+    names = [r.name for r in available]
+    assert len(names) == len(set(names))
+
+    # import from a non-existent agent dir is a no-op
+    imported = s.import_agent_project_skills("claude")
+    assert imported == []
+
+    print("tui helpers ok")
+
+
+if __name__ == "__main__":
+    test_tui_helpers()


### PR DESCRIPTION
Adds an interactive Textual-based TUI for managing Claude Code project skills.

Changes:
- New `sklm skills` command opens the skill manager.
- `sklm add` and `sklm rm` launch interactive pickers when run without arguments.
- New API helpers in `sklm/api.py`: `list_available_skills`, `list_workspace_skills`, `add_skills`, `remove_skills`, `import_agent_project_skills`.
- Existing skills found in `.claude/skills/` are auto-imported into the workspace when the TUI opens.
- `sklm status` now shows active project skills.
- Non-interactive `sklm add skill <name>` and `sklm rm skill <name>` remain unchanged.
- Adds `textual>=0.50.0` dependency and a small self-check test.

Closes the design produced by /sc:brainstorm + /sc:design.