### PR TITLE
fix: make add --from flag test resilient to Typer version differences

### DIFF
--- a/tests/test_sklm.py
+++ b/tests/test_sklm.py
@@ -1585,7 +1585,9 @@ class TestCLIIntegration:
         runner = CliRunner()
         result = runner.invoke(app, ["add", "--help"])
         assert result.exit_code == 0
-        assert "--from" in result.output
+        # Check for the help description text instead of the raw flag syntax,
+        # which can vary across Typer/Rich versions (e.g. ANSI wrapping).
+        assert "Git repository URL to install from" in result.output
 
     def test_uninstall_command(self, temp_dir, fake_skill_dir):
         """sklm uninstall doit supprimer un skill du store."""


### PR DESCRIPTION
Check for the help description text rather than the raw flag syntax, which can be rendered differently across Typer/Rich versions (e.g. with ANSI escape codes wrapping the output).